### PR TITLE
set cache control headers for all http statuses

### DIFF
--- a/server/com.dexels.navajo.entity/src/com/dexels/navajo/entity/continuations/EntityDispatcher.java
+++ b/server/com.dexels.navajo.entity/src/com/dexels/navajo/entity/continuations/EntityDispatcher.java
@@ -305,16 +305,15 @@ public class EntityDispatcher {
         } catch (Throwable ex) {
             result = handleException(ex, runner.getHttpResponse(), locale);
             
-            // Set Caching parameter
-            if (entity != null && entity.getMyCaching().size() > 0) {
-                setCachingHeader(result, entity, runner);
-            }
-
             if (access != null) {
                 boolean skipLogging = false;
                 if (ex instanceof EntityException) {
                     EntityException e = (EntityException) ex;
                     if (e.getCode() == EntityException.NOT_MODIFIED) {
+                    	// Set Caching parameter
+                        if (entity != null && entity.getMyCaching().size() > 0) {
+                            setCachingHeader(result, entity, runner);
+                        }
                         skipLogging = true;
                     } else if (e.getCode() == EntityException.ENTITY_NOT_FOUND && entityFound) {
                         skipLogging = true;

--- a/server/com.dexels.navajo.entity/src/com/dexels/navajo/entity/continuations/EntityDispatcher.java
+++ b/server/com.dexels.navajo.entity/src/com/dexels/navajo/entity/continuations/EntityDispatcher.java
@@ -311,7 +311,7 @@ public class EntityDispatcher {
                     EntityException e = (EntityException) ex;
                     if (e.getCode() == EntityException.NOT_MODIFIED) {
                     	// Set Caching parameter
-                        if (entity != null && entity.getMyCaching().size() > 0) {
+                        if (entity.getMyCaching().size() > 0) {
                             setCachingHeader(result, entity, runner);
                         }
                         skipLogging = true;


### PR DESCRIPTION
Currently the cache-control headers are only set for a successful response (200 OK), but they should also be set for a (304 Not Modified).

Client makes request.
Server gives response with cache-control headers (for instance max-age: 60)
Client makes request within max-age -> no request to the server (this is good)
Client makes request after max-age -> request to server with If-None-Match header
Server computes etag and decides to return 304 -> client should cache again for max-age (but only does that if the 304 includes cache-control headers).

With this fix the 304 response will also include the cache-control headers