### PR TITLE
added support for output type .bin 

### DIFF
--- a/server/com.dexels.navajo.entity/src/com/dexels/navajo/entity/continuations/EntityContinuationRunner.java
+++ b/server/com.dexels.navajo.entity/src/com/dexels/navajo/entity/continuations/EntityContinuationRunner.java
@@ -30,8 +30,10 @@ import com.dexels.navajo.document.Navajo;
 import com.dexels.navajo.document.NavajoException;
 import com.dexels.navajo.document.NavajoFactory;
 import com.dexels.navajo.document.NavajoLaszloConverter;
+import com.dexels.navajo.document.Property;
 import com.dexels.navajo.document.json.JSONTML;
 import com.dexels.navajo.document.json.JSONTMLFactory;
+import com.dexels.navajo.document.types.Binary;
 import com.dexels.navajo.script.api.AsyncRequest;
 import com.dexels.navajo.script.api.RequestQueue;
 import com.dexels.navajo.script.api.TmlRunnable;
@@ -227,6 +229,16 @@ public class EntityContinuationRunner implements TmlRunnable {
                 Writer w = new OutputStreamWriter(out);
                 NavajoLaszloConverter.writeBirtXml(responseNavajo,w );
                 w.close();
+            } else if (outputFormat.equals("bin")) {
+				// find the first binary property and output that
+				for (Property property : responseNavajo.getRootMessage().getMessage(0).getAllProperties()) {
+					if (Property.BINARY_PROPERTY.equals(property.getType())) {
+						out.write(((Binary) property.getTypedValue()).getData());
+						break;
+					}
+				}
+				out.flush();
+				out.close();
             } else {
                 response.setHeader("content-type", "text/xml");
                 responseNavajo.write(out);

--- a/server/com.dexels.navajo.entity/src/com/dexels/navajo/entity/continuations/EntityContinuationRunner.java
+++ b/server/com.dexels.navajo.entity/src/com/dexels/navajo/entity/continuations/EntityContinuationRunner.java
@@ -230,15 +230,15 @@ public class EntityContinuationRunner implements TmlRunnable {
                 NavajoLaszloConverter.writeBirtXml(responseNavajo,w );
                 w.close();
             } else if (outputFormat.equals("bin")) {
-				// find the first binary property and output that
-				for (Property property : responseNavajo.getRootMessage().getMessage(0).getAllProperties()) {
-					if (Property.BINARY_PROPERTY.equals(property.getType())) {
-						out.write(((Binary) property.getTypedValue()).getData());
-						break;
-					}
-				}
-				out.flush();
-				out.close();
+                // find the first binary property and output that
+                for (Property property : responseNavajo.getRootMessage().getMessage(0).getAllProperties()) {
+                    if (Property.BINARY_PROPERTY.equals(property.getType())) {
+                        out.write(((Binary) property.getTypedValue()).getData());
+                        break;
+                    }
+                }
+                out.flush();
+                out.close();
             } else {
                 response.setHeader("content-type", "text/xml");
                 responseNavajo.write(out);

--- a/server/com.dexels.navajo.entity/src/com/dexels/navajo/entity/continuations/EntityDispatcher.java
+++ b/server/com.dexels.navajo.entity/src/com/dexels/navajo/entity/continuations/EntityDispatcher.java
@@ -50,7 +50,7 @@ public class EntityDispatcher {
     private final static Logger statLogger = LoggerFactory.getLogger("stats");
 
     private final static String DEFAULT_OUTPUT_FORMAT = "json";
-    private static final Set<String> SUPPORTED_OUTPUT = new HashSet<String>(Arrays.asList("json", "xml", "birt", "tml"));
+    private static final Set<String> SUPPORTED_OUTPUT = new HashSet<String>(Arrays.asList("json", "xml", "birt", "tml", "bin"));
 
     private EntityManager myManager;
     private AuthenticationMethodBuilder authMethodBuilder;


### PR DESCRIPTION
added support for output type .bin that outputs the first top level binary of an entity in its own format, useful for ical (.ics) files for instance. 

In order to migrate from articles to entities it is needed to have functionality that an entity can output raw ical. Entities already support different output formats (json, xml, birt, tml). I've added a new one called bin (for binary), that will take the first binary property of the entity message and returns its contents directly (without wrapping it in json/xml).