### PR TITLE
oracle dbidentifier null check

### DIFF
--- a/server/com.dexels.navajo.adapters/src/com/dexels/navajo/adapter/sqlmap/SQLMapHelper.java
+++ b/server/com.dexels.navajo.adapters/src/com/dexels/navajo/adapter/sqlmap/SQLMapHelper.java
@@ -66,7 +66,7 @@ public class SQLMapHelper {
 		}
 		
 		if ((param == null) || (param instanceof NavajoType && !(param instanceof Binary) && ((NavajoType) param).isEmpty())) {
-			if (SQLMapConstants.POSTGRESDB.equals(dbIdentifier) || SQLMapConstants.ENTERPRISEDB.equals(dbIdentifier)) { 
+			if (SQLMapConstants.POSTGRESDB.equals(dbIdentifier) || SQLMapConstants.ENTERPRISEDB.equals(dbIdentifier) || SQLMapConstants.ORACLEDB.equals(dbIdentifier)) { 
 				if (debug) {
 					Access.writeToConsole(access, "Had to do something in order to not get the cast error from a null value, because it concerns " + dbIdentifier + "\n");
 				}


### PR DESCRIPTION
While working on issue #552, I encountered an issue of not checking a null parameter in the SQLMapHelper.java when the dbIdentifier was equal to Oracle DB. 