### PR TITLE
Add expiration date for BinaryStoreAdapter

### DIFF
--- a/server/com.dexels.navajo.resource.http/src/com/dexels/navajo/resource/http/HttpResource.java
+++ b/server/com.dexels.navajo.resource.http/src/com/dexels/navajo/resource/http/HttpResource.java
@@ -6,6 +6,7 @@ No part of the Navajo Project, including this file, may be copied, modified, pro
 package com.dexels.navajo.resource.http;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.Optional;
 
 import org.reactivestreams.Publisher;
@@ -58,5 +59,6 @@ public interface HttpResource {
 	
 	public String getURL();
 	public String expiringURL(String tenant, String bucket, String id, long expiration);
+	public String expiringURL(String tenant, String bucket, String id, Date expire);
 	public Binary lazyBinary(String tenant, String bucket, String id, long expire) throws IOException;
 }

--- a/server/com.dexels.navajo.resource.http/src/com/dexels/navajo/resource/http/adapter/BinaryStoreAdapter.java
+++ b/server/com.dexels.navajo.resource.http/src/com/dexels/navajo/resource/http/adapter/BinaryStoreAdapter.java
@@ -6,6 +6,8 @@ No part of the Navajo Project, including this file, may be copied, modified, pro
 package com.dexels.navajo.resource.http.adapter;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,10 +85,11 @@ public class BinaryStoreAdapter implements Mappable {
 		return HttpResourceFactory.getInstance().getHttpResource(resource).expiringURL(access.getTenant(), bucket, binaryHash,expiration);
 	}
 
-//	public String temporaryURL(Binary binary, String resource, String bucket, long expiration) throws IOException {
-//		return temporaryURL(binary.getHexDigest(), resource, bucket, expiration);
-//	}
-//
+	public String temporaryURL(String binaryHash, String resource, String bucket, Date expirationDate) throws IOException {
+		return HttpResourceFactory.getInstance().getHttpResource(resource)
+				.expiringURL(access.getTenant(), bucket, binaryHash, expirationDate);
+	}
+
 	public void setExpiration(Object expiration) {
 		logger.debug("Setting expiration: "+expiration);
 		if(expiration instanceof Long) {
@@ -98,7 +101,12 @@ public class BinaryStoreAdapter implements Mappable {
 			this.expiration = (Integer)expiration;
 			return;
 		}
+
 		logger.info("Error setting expiration: Weird type: "+expiration.getClass());
+	}
+
+	public void setExpirationDate(Date expirationDate) {
+		this.expirationDate = expirationDate;
 	}
 
 	public void setBinary(Binary binary) {
@@ -118,6 +126,7 @@ public class BinaryStoreAdapter implements Mappable {
 	}
 
 	private long expiration;
+	private Date expirationDate;
 	private Binary binary;
 	private String binaryHash;
 	private String resource;
@@ -125,13 +134,14 @@ public class BinaryStoreAdapter implements Mappable {
 	private String putResult;
     private int deleteResult = -1;
 
-
-
 	public String getTemporaryURL() throws IOException {
 		String hash = binaryHash!=null ? binaryHash : binary.getHexDigest();
+		if (expirationDate != null) {
+			return temporaryURL(hash, resource, bucket, expirationDate);
+		}
+
 		return temporaryURL(hash, resource, bucket, expiration);
 	}
-
 
 	public String getPutResult() throws IOException {
 	    if (this.putResult == null) {

--- a/server/com.dexels.navajo.resource.http/src/com/dexels/navajo/resource/http/bundle/adapters.xml
+++ b/server/com.dexels.navajo.resource.http/src/com/dexels/navajo/resource/http/bundle/adapters.xml
@@ -8,9 +8,11 @@
             <value name="binaryHash" type="string" required="false" direction="in"/>
             <value name="binary" type="binary" required="false" direction="in"/>
             <value name="expiration" type="long" required="false" direction="in"/>
+            <value name="expirationDate" type="date" required="false" direction="in"/>
             <value name="putResult" type="string" required="false" direction="out"/>
             <value name="headResult" type="integer" required="false" direction="out"/>
             <value name="deleteResult" type="integer" required="false" direction="out"/>
+            <value name="temporaryURL" type="string" required="false" direction="out"/>
         </values>
         <methods>
             <method name="put">
@@ -23,10 +25,9 @@
             </method>
             <method name="getURL">
                 <param name="binaryHash"  field="binaryHash" type="string" required="true"/>
-                <param name="expiration" type="integer" required="true" />
-                <param name="url" field="temporaryURL" type="string" required="false"/>
+                <param name="expiration" field="expiration" type="integer" required="false" />
+                <param name="expirationDate" field="expirationDate" type="date" required="false" />
             </method>
         </methods>
     </map>
-    
-    </adapterdef>
+</adapterdef>

--- a/server/com.dexels.navajo.resource.http/src/com/dexels/navajo/resource/http/impl/ResourceComponent.java
+++ b/server/com.dexels.navajo.resource.http/src/com/dexels/navajo/resource/http/impl/ResourceComponent.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -189,12 +190,18 @@ public class ResourceComponent implements HttpResource {
 
 	@Override
 	public String expiringURL(String tenant, String bucket, String id, long expire) {
-		long unixTimestamp = Instant.now().getEpochSecond()+expire;
-		long exp = unixTimestamp+expire;
-		String totalURL = assemblePublicURL(tenant,bucket, id)+"?expires="+exp+"&sig="+sign(resolveBucket(tenant, bucket), id,exp);
-	    //logger.debug("Assembled public url {} to {} in {} lasting {} seconds into the future", totalURL, id, bucket, expire);
+		return makeExpiringURL(tenant, bucket, id, Instant.now().getEpochSecond() + expire);
+	}
 
-		return totalURL;
+	@Override
+	public String expiringURL(String tenant, String bucket, String id, Date expire) {
+		return makeExpiringURL(tenant, bucket, id, expire.getTime() / 1000);
+	}
+
+	private String makeExpiringURL(String tenant, String bucket, String id, long ttlInSeconds) {
+		return assemblePublicURL(tenant,bucket, id)
+				+ "?expires=" + ttlInSeconds
+				+ "&sig=" + sign(resolveBucket(tenant, bucket), id, ttlInSeconds);
 	}
 
 	private String sign(String bucket, String id, long expirationTime) {


### PR DESCRIPTION
Instead of only accepting seconds for expiration, this commit will add
the ability to set an expiration date.

This is needed because I want to generate temporary urls with a set end date. See 108efea89ebf214d63320421d6c2d1567302d1db for usage and more explanation.