### PR TITLE
Fix #588 by not saving the byte array when not used

### DIFF
--- a/server/com.dexels.navajo.compiler.tsl/src/com/dexels/navajo/compiler/tsl/custom/CustomJavaFileObject.java
+++ b/server/com.dexels.navajo.compiler.tsl/src/com/dexels/navajo/compiler/tsl/custom/CustomJavaFileObject.java
@@ -45,7 +45,6 @@ public class CustomJavaFileObject implements JavaFileObject {
 
 			IOUtils.copy(is, baos);
 			byte[] data = baos.toByteArray();
-			setContents(data);
 			File generated = File.createTempFile("compile", ".java");
 			File parent = generated.getParentFile();
 			File current = parent;
@@ -61,6 +60,11 @@ public class CustomJavaFileObject implements JavaFileObject {
 			fos.close();
 			this.name = tmp.getAbsolutePath();
 			this.lazyURL = Paths.get(tmp.getAbsolutePath()).toUri();
+			// Only need to save the byte array if we do not have a lazyURL
+			if( this.lazyURL == null )
+			{
+	            setContents(data);
+			}
 		}
 	}
 


### PR DESCRIPTION
I don't see any way that this can be bad, it's a private field so all usages can be inspected, and it won't be used if lazyURL is not null